### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "vccw/wp-cli-scaffold-movefile",
     "description": "Get informations as YAML format for Wordmove's Movefile from WordPress",
+	"type": "wp-cli-package",
     "homepage": "https://github.com/vccw-team/wp-cli-scaffold-movefile",
     "license": "GPL-2.0",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
