### PR TITLE
Fix vhost URL & enable Movefile syntax highlithing

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -53,7 +53,7 @@ class WP_CLI_Scaffold_Movefile extends WP_CLI_Command
 		);
 
 		if ( empty( $args[0] ) ) {
-			$filename = getcwd() . "/Movefile.yml";
+			$filename = getcwd() . "/Movefile";
 		} else {
 			$filename = $args[0];
 		}

--- a/cli.php
+++ b/cli.php
@@ -38,13 +38,13 @@ class WP_CLI_Scaffold_Movefile extends WP_CLI_Command
 	function __invoke( $args, $assoc_args )
 	{
 		$vars = array(
-			'site_url' => site_url(),
+			'home_url'       => home_url(),
 			'wordpress_path' => WP_CLI::get_runner()->config['path'],
-			'db_name' => DB_NAME,
-			'db_user' => DB_USER,
-			'db_pass' => DB_PASSWORD,
-			'db_host' => DB_HOST,
-			'db_charset' => DB_CHARSET,
+			'db_name'        => DB_NAME,
+			'db_user'        => DB_USER,
+			'db_pass'        => DB_PASSWORD,
+			'db_host'        => DB_HOST,
+			'db_charset'     => DB_CHARSET,
 		);
 
 		$movefile = WP_CLI\Utils\mustache_render(
@@ -53,7 +53,7 @@ class WP_CLI_Scaffold_Movefile extends WP_CLI_Command
 		);
 
 		if ( empty( $args[0] ) ) {
-			$filename = getcwd() . "/Movefile";
+			$filename = getcwd() . "/Movefile.yml";
 		} else {
 			$filename = $args[0];
 		}

--- a/features/load-wp-cli.feature
+++ b/features/load-wp-cli.feature
@@ -8,7 +8,7 @@ Feature: Test that WP-CLI loads.
 
     When I run `wp scaffold movefile`
     Then the return code should be 0
-    And the Movefile file should exist
+    And the Movefile.yml file should exist
     And STDOUT should contain:
       """
       Success:
@@ -27,8 +27,8 @@ Feature: Test that WP-CLI loads.
 
     When I run `wp scaffold movefile < session`
     Then the return code should be 0
-    And the Movefile file should exist
-    And the Movefile file should contain:
+    And the Movefile.yml file should exist
+    And the Movefile.yml file should contain:
       """
       local:
       """
@@ -39,7 +39,7 @@ Feature: Test that WP-CLI loads.
 
   Scenario: Don't overwrite Movefile
     Given a WP install
-    And a Movefile file:
+    And a Movefile.yml file:
       """
       Hello
       """
@@ -50,8 +50,8 @@ Feature: Test that WP-CLI loads.
 
     When I run `wp scaffold movefile < session`
     Then the return code should be 0
-    And the Movefile file should exist
-    And the Movefile file should contain:
+    And the Movefile.yml file should exist
+    And the Movefile.yml file should contain:
       """
       Hello
       """
@@ -62,15 +62,15 @@ Feature: Test that WP-CLI loads.
 
   Scenario: Force overwrite Movefile
     Given a WP install
-    And a Movefile file:
+    And a Movefile.yml file:
       """
       Hello
       """
 
     When I run `wp scaffold movefile --force`
     Then the return code should be 0
-    And the Movefile file should exist
-    And the Movefile file should contain:
+    And the Movefile.yml file should exist
+    And the Movefile.yml file should contain:
       """
       local:
       """

--- a/features/load-wp-cli.feature
+++ b/features/load-wp-cli.feature
@@ -8,7 +8,7 @@ Feature: Test that WP-CLI loads.
 
     When I run `wp scaffold movefile`
     Then the return code should be 0
-    And the Movefile.yml file should exist
+    And the Movefile file should exist
     And STDOUT should contain:
       """
       Success:
@@ -27,8 +27,8 @@ Feature: Test that WP-CLI loads.
 
     When I run `wp scaffold movefile < session`
     Then the return code should be 0
-    And the Movefile.yml file should exist
-    And the Movefile.yml file should contain:
+    And the Movefile file should exist
+    And the Movefile file should contain:
       """
       local:
       """
@@ -39,7 +39,7 @@ Feature: Test that WP-CLI loads.
 
   Scenario: Don't overwrite Movefile
     Given a WP install
-    And a Movefile.yml file:
+    And a Movefile file:
       """
       Hello
       """
@@ -50,8 +50,8 @@ Feature: Test that WP-CLI loads.
 
     When I run `wp scaffold movefile < session`
     Then the return code should be 0
-    And the Movefile.yml file should exist
-    And the Movefile.yml file should contain:
+    And the Movefile file should exist
+    And the Movefile file should contain:
       """
       Hello
       """
@@ -62,15 +62,15 @@ Feature: Test that WP-CLI loads.
 
   Scenario: Force overwrite Movefile
     Given a WP install
-    And a Movefile.yml file:
+    And a Movefile file:
       """
       Hello
       """
 
     When I run `wp scaffold movefile --force`
     Then the return code should be 0
-    And the Movefile.yml file should exist
-    And the Movefile.yml file should contain:
+    And the Movefile file should exist
+    And the Movefile file should contain:
       """
       local:
       """

--- a/templates/Movefile.mustache
+++ b/templates/Movefile.mustache
@@ -1,5 +1,5 @@
 local:
-  vhost: "{{ site_url }}"
+  vhost: "{{ home_url }}"
   wordpress_path: "{{ wordpress_path }}" # use an absolute path here
 
   database:


### PR DESCRIPTION
- Fix vhost URL: site_url ≠ home_url
- Add ".yml" extension to enable syntax highlighting by default (see: https://github.com/welaika/wordmove/issues/46)